### PR TITLE
feat: problemTypeFunctionMethod Wordcloud 차트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
 
   <title>chart | Algoview</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.zingchart.com/zingchart.min.js"></script>
   <link rel="stylesheet" href="/src/css/style.css">
 </head>
 
@@ -154,7 +155,7 @@
             </li>
             <li>
               <h4 class="chart-tit">problem-type-function-method-wordcloud-chart</h4>
-              <canvas id="problem-type-function-method-wordcloud-chart"></canvas>
+              <div id="problemTypeFunctionMethodWordcloudChart"></div>
             </li>
             <li>
               <h4 class="chart-tit">problem-type-module-wordcloud-chart</h4>

--- a/src/js/charts/categoryProblemType.js
+++ b/src/js/charts/categoryProblemType.js
@@ -2,12 +2,14 @@ import getProblemTypeData from './problemTypeChart.js';
 import getProblemTypeMethod from './problemTypeMethodChart.js';
 import getProblemTypeFunctionData from './problemTypeFunctionChart.js';
 import getProblemTypeFunctionMethodData from './problemTypeFunctionMethodChart.js';
+import getProblemTypeWCData from './problemTypeFunctionMethodWC.js';
 
 function getCategoryProblemType(props) {
   getProblemTypeData(...props);
   getProblemTypeMethod(...props);
   getProblemTypeFunctionData(...props);
   getProblemTypeFunctionMethodData(...props);
+  getProblemTypeWCData(...props);
 }
 
 export default getCategoryProblemType;

--- a/src/js/charts/problemTypeFunctionMethodWC.js
+++ b/src/js/charts/problemTypeFunctionMethodWC.js
@@ -1,0 +1,78 @@
+zingchart.MODULESDIR = 'https://cdn.zingchart.com/modules/';
+
+function getProblemTypeWCData(data, lang) {
+  if (lang === 'py') {
+    const problemTypeFunctionMethodData = data['py']['problem_type_function_method'];
+
+    const dataset = [];
+    for (const [problemType, value] of Object.entries(problemTypeFunctionMethodData)) {
+      const words = []
+      for (const [funcName, count] of Object.entries(value)) {
+        words.push({
+          text: funcName,
+          count: count
+        })
+      }
+
+      dataset.push({
+        title: problemType,
+        words: words
+      })
+    }
+
+    // 배치
+    const totalCnt = dataset.length;
+    const col = totalCnt === 1 ? 1 : (totalCnt <= 4 ? 2 : 3);
+    const width = col === 1 ? '100' : (col === 2 ? '49' : '32');
+
+    // 워드클라우드 차트 집합
+    var myConfig = {
+      graphset: []
+    };
+
+    dataset.forEach((data, idx) => {
+      const wc = {
+        type: 'wordcloud',
+        // backgroundColor: '#393b46', // 다크모드
+        backgroundColor: 'white',
+        width: width + '%',
+        height: '150',
+        x: idx % col * width + '%',
+        y: Math.floor(idx / col) * 200,
+        title: {
+          text: data['title'],
+          backgroundColor: 'none',
+          // fontColor: '#fff', // 다크모드
+          fontColor: '#000',
+          fontSize: '16px',
+          y: '2%',
+        },
+        options: {
+          words: data['words'],
+          minLength: 1,
+          maxItems: 40,
+          maxFontSize: '50px',
+          minFontSize: '14px',
+          // colorType: 'palette',
+          // palette: ['#2196F3', '#3F51B5', '#42A5F5', '#5C6BC0', '#64B5F6', '#7986CB', '#90CAF9', '#9FA8DA', '#BBDEFB', '#C5CAE9']
+        },
+        plotarea: {
+          margin: '30px 5px 5px',
+        },
+      }
+
+      myConfig.graphset.push(wc);
+    })
+
+
+    // 워드클라우드 렌더링
+    zingchart.render({
+      id: 'problemTypeFunctionMethodWordcloudChart',
+      data: myConfig,
+      width: '100%',
+      height: '600',
+    });
+  }
+}
+
+export default getProblemTypeWCData;


### PR DESCRIPTION
<img width="1023" alt="스크린샷 2023-06-08 오후 3 36 41" src="https://github.com/Algorithm-Coding-Test-Data-Analysis/algoview/assets/90684277/190fef67-6391-4e08-9114-f484883c1d50">

zingChart 라이브러리 사용해서 wordcloud 구현했습니다. index.html에 canvas태그 대신 div태그를 사용해야하고, id는 케밥케이스를 사용할 수 없어서 카멜케이스로 바꿔서 작성했습니다.
차트가 1개일때는 꽉 차게, 2-4개일때는 2x2, 5개 이상일때 nx3로 정렬되게 만들었습니다.

워드클라우드 텍스트 색상에 적용할 테마, 다크모드에서 워드클라우드 배경색깔, 워드클라우드 차트 개수row에 따라 동적으로 height 늘어나고 줄어들게 만드는 스타일 작업 남은 것 같습니다.